### PR TITLE
Introduce Configurations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
   # Set it to 3 to support 8-bit color graphics (256 colors per channel)
   # for libraries that care about the value set.
   FORCE_COLOR: 3
+  NUMBA_DISABLE_JIT: 1 # this is so codecov can capture tests of jit functions
 
 jobs:
   pre-commit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,8 +141,6 @@ ignore = [
   "PLR2004",  # Magic value used in comparison
   "PLR1714",
 ]
-# Uncomment if using a _compat.typing backport
-# typing-modules = ["tpx3awkward._compat.typing"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["T20"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "tqdm",
   "pyarrow",
   "tables",
+  "pydantic",
 ]
 
 [project.urls]

--- a/src/tpx3awkward/__init__.py
+++ b/src/tpx3awkward/__init__.py
@@ -1,19 +1,23 @@
 from ._version import version as __version__
 from .processing import (
+    Tpx3Config,
     cluster_raw_df,
     convert_tpx3_file,
     convert_tpx3_files,
     convert_tpx3_files_parallel,
     find_unmatched_tpx3_files,
+    read_parquet_config,
     tpx_to_raw_df,
 )
 
 __all__ = [
+    "Tpx3Config",
     "__version__",
     "cluster_raw_df",
     "convert_tpx3_file",
     "convert_tpx3_files",
     "convert_tpx3_files_parallel",
     "find_unmatched_tpx3_files",
+    "read_parquet_config",
     "tpx_to_raw_df",
 ]

--- a/src/tpx3awkward/__init__.py
+++ b/src/tpx3awkward/__init__.py
@@ -1,7 +1,7 @@
 from ._version import version as __version__
 from .processing import (
     Tpx3Config,
-    cluster_raw_df,
+    cluster_decoded_df,
     convert_tpx3_file,
     convert_tpx3_files,
     convert_tpx3_files_parallel,
@@ -12,7 +12,7 @@ from .processing import (
 __all__ = [
     "Tpx3Config",
     "__version__",
-    "cluster_raw_df",
+    "cluster_decoded_df",
     "convert_tpx3_file",
     "convert_tpx3_files",
     "convert_tpx3_files_parallel",

--- a/src/tpx3awkward/processing/__init__.py
+++ b/src/tpx3awkward/processing/__init__.py
@@ -1,4 +1,4 @@
-from .cluster import cluster_raw_df
+from .cluster import cluster_decoded_df
 from .config import Tpx3Config
 from .decoding import decode_tpx3_binary
 from .files import find_unmatched_tpx3_files, raw_as_numpy, read_parquet_config
@@ -6,7 +6,7 @@ from .pipeline import convert_tpx3_file, convert_tpx3_files, convert_tpx3_files_
 
 __all__ = [
     "Tpx3Config",
-    "cluster_raw_df",
+    "cluster_decoded_df",
     "convert_tpx3_file",
     "convert_tpx3_files",
     "convert_tpx3_files_parallel",

--- a/src/tpx3awkward/processing/__init__.py
+++ b/src/tpx3awkward/processing/__init__.py
@@ -1,13 +1,16 @@
 from .cluster import cluster_raw_df
+from .config import Tpx3Config
 from .decoding import tpx_to_raw_df
-from .files import find_unmatched_tpx3_files
+from .files import find_unmatched_tpx3_files, read_parquet_config
 from .pipeline import convert_tpx3_file, convert_tpx3_files, convert_tpx3_files_parallel
 
 __all__ = [
+    "Tpx3Config",
     "cluster_raw_df",
     "convert_tpx3_file",
     "convert_tpx3_files",
     "convert_tpx3_files_parallel",
     "find_unmatched_tpx3_files",
+    "read_parquet_config",
     "tpx_to_raw_df",
 ]

--- a/src/tpx3awkward/processing/cluster.py
+++ b/src/tpx3awkward/processing/cluster.py
@@ -2,7 +2,7 @@ import numba
 import numpy as np
 import pandas as pd
 
-TIMESTAMP_VALUE = 1.5625 * 1e-9  # each raw timestamp is 1.5625 seconds
+TIMESTAMP_VALUE = 1.5625 * 1e-9  # each raw timestamp is 1.5625 nanoseconds
 MICROSECOND = 1e-6
 
 # We have had decent success with these values, but do not know for sure if they are optimal.
@@ -12,7 +12,7 @@ DEFAULT_CLUSTER_TW_MICROSECONDS = 0.3
 DEFAULT_CLUSTER_TW = int(DEFAULT_CLUSTER_TW_MICROSECONDS * MICROSECOND / TIMESTAMP_VALUE)
 
 
-def cluster(df, tw, radius, estimate_energy: bool = False, correct_timewalk: bool = False):
+def _cluster(df, tw, radius, estimate_energy: bool = False, correct_timewalk: bool = False):
     cols = ["t", "x", "y", "ToT", "t"]
 
     if estimate_energy:
@@ -20,16 +20,18 @@ def cluster(df, tw, radius, estimate_energy: bool = False, correct_timewalk: boo
     if correct_timewalk:
         cols.append("t_corr")
 
-    events = df[cols].to_numpy()
-    events[:, 0] = np.floor_divide(events[:, 0], tw)  # Bin timestamps into time windows
+    tw_ts_ticks = int(tw * MICROSECOND / TIMESTAMP_VALUE)
 
-    labels = get_cluster_labels(events, tw, radius)
+    events = df[cols].to_numpy()
+    events[:, 0] = np.floor_divide(events[:, 0], tw_ts_ticks)  # Bin timestamps into time windows
+
+    labels = _get_cluster_labels(events, tw_ts_ticks, radius)
 
     return labels, events[:, 1:]
 
 
 @numba.jit(nopython=True, cache=True)
-def get_cluster_labels(events, tw, radius):
+def _get_cluster_labels(events, tw, radius):
     n = len(events)
     labels = np.full(n, -1, dtype=np.int64)
     cluster_id = 0
@@ -57,7 +59,7 @@ def get_cluster_labels(events, tw, radius):
 
 
 @numba.jit(nopython=True, cache=True)
-def group_indices(labels):
+def _group_indices(labels):
     """
     Group indices by cluster ID using pre-allocated arrays in a Numba-optimized way.
 
@@ -90,13 +92,12 @@ def group_indices(labels):
 
 
 @numba.jit(nopython=True, cache=True)
-def centroid_clusters(
+def _centroid_clusters(
     cluster_arr: np.ndarray,
     events: np.ndarray,
     estimate_energy: bool = False,
     correct_timewalk: bool = False,
 ) -> tuple[np.ndarray]:
-
     num_clusters = cluster_arr.shape[0]
     max_cluster = cluster_arr.shape[1]
     t = np.zeros(num_clusters, dtype="uint64")
@@ -138,7 +139,7 @@ def centroid_clusters(
     return t, xc, yc, ToT_max, ToT_sum, n, e_sum, t_corr
 
 
-def ingest_cent_data(
+def _ingest_cent_data(
     data: np.ndarray, estimate_energy: bool = False, correct_timewalk: bool = False
 ) -> dict[str, np.ndarray]:
     """
@@ -174,14 +175,34 @@ def cluster_decoded_df(
     df: pd.DataFrame,
     tw: float,
     radius: int,
-    correct_timewalk: bool = False,
 ) -> pd.DataFrame:
-    # apply gap (needed for correct pixel mapping to energy calibrations)
+    """
+    Cluster and centroid a decoded DataFrame.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Decoded dataframe with columns ['x', 'y', 'ToT', 't', 'chip'].
+        May also include optional columns 'e' and 't_corr'.
+    tw : float
+        Time Window for the clustering algorithm, in microseconds.
+    radius : int,
+        Radius for the clustering algorithm, in pixels.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns ['t', 'xc', 'yc', 'ToT_max', 'ToT_sum', 'n'].
+        Includes columns 'e_sum' and/or 't_corr' depending on the input DataFrame.
+    """
     estimate_energy: bool = "e" in df.columns
-    cluster_labels, events = cluster(df, tw, radius, estimate_energy=estimate_energy, correct_timewalk=correct_timewalk)
+    correct_timewalk: bool = "t_corr" in df.columns
+
+    cluster_labels, events = _cluster(df, tw, radius, estimate_energy=estimate_energy, correct_timewalk=correct_timewalk)
     df["cluster_id"] = cluster_labels
-    cluster_array = group_indices(cluster_labels)
-    data = centroid_clusters(
+    cluster_array = _group_indices(cluster_labels)
+
+    data = _centroid_clusters(
         cluster_array,
         events,
         estimate_energy=estimate_energy,
@@ -189,7 +210,7 @@ def cluster_decoded_df(
     )
 
     return (
-        pd.DataFrame(ingest_cent_data(data, estimate_energy=estimate_energy, correct_timewalk=correct_timewalk))
+        pd.DataFrame(_ingest_cent_data(data, estimate_energy=estimate_energy, correct_timewalk=correct_timewalk))
         .sort_values(["t", "xc", "yc", "ToT_max", "ToT_sum"])
         .reset_index(drop=True)
     )

--- a/src/tpx3awkward/processing/cluster.py
+++ b/src/tpx3awkward/processing/cluster.py
@@ -2,7 +2,7 @@ import numba
 import numpy as np
 import pandas as pd
 
-from .corrections import estimate_energies, timewalk_corr_exp, trim_corr
+from .corrections import timewalk_corr_exp, trim_corr
 
 TIMESTAMP_VALUE = 1.5625 * 1e-9  # each raw timestamp is 1.5625 seconds
 MICROSECOND = 1e-6
@@ -173,7 +173,7 @@ def ingest_cent_data(
     return dict(zip(keys, data, strict=False))
 
 
-def cluster_raw_df(
+def cluster_decoded_df(
     df: pd.DataFrame,
     tw: float = DEFAULT_CLUSTER_TW,
     radius: int = DEFAULT_CLUSTER_RADIUS,
@@ -185,8 +185,6 @@ def cluster_raw_df(
     # apply gap (needed for correct pixel mapping to energy calibrations)
     if trim_correct:
         df = trim_corr(df, trim_correct)
-    if include_energy:
-        df["e"] = estimate_energies(df["x"].to_numpy(), df["y"].to_numpy(), df["ToT"].to_numpy(), energy_calib)
     cluster_labels, events = cluster(df, tw, radius, include_energy=include_energy)
     df["cluster_id"] = cluster_labels
     cluster_array = group_indices(cluster_labels)

--- a/src/tpx3awkward/processing/cluster.py
+++ b/src/tpx3awkward/processing/cluster.py
@@ -2,8 +2,6 @@ import numba
 import numpy as np
 import pandas as pd
 
-from .corrections import timewalk_corr_exp, trim_corr
-
 TIMESTAMP_VALUE = 1.5625 * 1e-9  # each raw timestamp is 1.5625 seconds
 MICROSECOND = 1e-6
 
@@ -14,16 +12,13 @@ DEFAULT_CLUSTER_TW_MICROSECONDS = 0.3
 DEFAULT_CLUSTER_TW = int(DEFAULT_CLUSTER_TW_MICROSECONDS * MICROSECOND / TIMESTAMP_VALUE)
 
 
-def cluster(
-    df,
-    tw=DEFAULT_CLUSTER_TW,
-    radius=DEFAULT_CLUSTER_RADIUS,
-    include_energy: bool = False,
-):
+def cluster(df, tw, radius, estimate_energy: bool = False, correct_timewalk: bool = False):
     cols = ["t", "x", "y", "ToT", "t"]
 
-    if include_energy:
+    if estimate_energy:
         cols.append("e")
+    if correct_timewalk:
+        cols.append("t_corr")
 
     events = df[cols].to_numpy()
     events[:, 0] = np.floor_divide(events[:, 0], tw)  # Bin timestamps into time windows
@@ -34,7 +29,7 @@ def cluster(
 
 
 @numba.jit(nopython=True, cache=True)
-def get_cluster_labels(events, tw=DEFAULT_CLUSTER_TW, radius=DEFAULT_CLUSTER_RADIUS):
+def get_cluster_labels(events, tw, radius):
     n = len(events)
     labels = np.full(n, -1, dtype=np.int64)
     cluster_id = 0
@@ -98,8 +93,8 @@ def group_indices(labels):
 def centroid_clusters(
     cluster_arr: np.ndarray,
     events: np.ndarray,
-    include_energy: bool = False,
-    timewalk_correct: bool = False,
+    estimate_energy: bool = False,
+    correct_timewalk: bool = False,
 ) -> tuple[np.ndarray]:
 
     num_clusters = cluster_arr.shape[0]
@@ -110,8 +105,10 @@ def centroid_clusters(
     ToT_max = np.zeros(num_clusters, dtype="uint32")
     ToT_sum = np.zeros(num_clusters, dtype="uint32")
     n = np.zeros(num_clusters, dtype="ubyte")
-    e_sum = np.zeros(num_clusters, dtype="float32")
-    t_corr = np.zeros(num_clusters, dtype="uint64")
+
+    # must always define arrays becuase numba wants identical return signatures
+    e_sum = np.zeros(num_clusters, dtype="float32") if estimate_energy else np.empty(0, dtype="float32")
+    t_corr = np.zeros(num_clusters, dtype="uint64") if correct_timewalk else np.empty(0, dtype="uint64")
 
     for cluster_id in range(num_clusters):
         _ToT_max = np.ushort(0)
@@ -121,15 +118,15 @@ def centroid_clusters(
                 if events[event, 2] > _ToT_max:  # find the max ToT, assign, use that time
                     _ToT_max = events[event, 2]
                     t[cluster_id] = events[event, 3]
-                    if timewalk_correct:
-                        t_corr[cluster_id] = events[event, 3] - timewalk_corr_exp(_ToT_max)
+                    if correct_timewalk:
+                        t_corr[cluster_id] = events[event, 5]
                     ToT_max[cluster_id] = _ToT_max
                 xc[cluster_id] += events[event, 0] * events[event, 2]  # x and y centroids by time over threshold
                 yc[cluster_id] += events[event, 1] * events[event, 2]
                 ToT_sum[cluster_id] += events[event, 2]  # calcuate sum
                 n[cluster_id] += np.ubyte(1)  # number of events in cluster
 
-                if include_energy:
+                if estimate_energy:
                     e_sum[cluster_id] += events[event, 4]
             else:
                 break
@@ -142,61 +139,57 @@ def centroid_clusters(
 
 
 def ingest_cent_data(
-    data: np.ndarray, include_energy: bool = False, timewalk_correct: bool = False
+    data: np.ndarray, estimate_energy: bool = False, correct_timewalk: bool = False
 ) -> dict[str, np.ndarray]:
     """
-    Performs the centroiding of a group of clusters.
+    Package np.ndarray into a dict with keys associated with the names of the columns dataframe.
 
     Parameters
     ----------
     data : np.ndarray
         The stream of cluster data from cluster_arr_to_cent()
-    include_energy : bool, optional
-        Whether the data includes energy sum (e_sum). Default is False.
+    estimate_energy : bool, optional
+        Whether the data includes estimated energy sum (e_sum). Default is False.
 
     Returns
     -------
     Dict[str, np.ndarray]
         A dictionary with keys:
         ['t', 'xc', 'yc', 'ToT_max', 'ToT_sum', 'n']
-        or
-        ['t', 'xc', 'yc', 'ToT_max', 'ToT_sum', 'e_sum', 'n'] if include_energy=True
+        and optional keys 'e_sum' and 't_corr'
     """
+    # first 6 columns are always included
     key_string = "t,xc,yc,ToT_max,ToT_sum,n"
+    rdict = dict(zip(key_string.split(","), data[:6], strict=True))
 
-    if include_energy:
-        key_string += ",e_sum"
-    if timewalk_correct:
-        key_string += ",t_corr"
+    if estimate_energy:
+        rdict["e_sum"] = data[6]
+    if correct_timewalk:
+        rdict["t_corr"] = data[7]
 
-    keys = key_string.split(",")
-    return dict(zip(keys, data, strict=False))
+    return rdict
 
 
 def cluster_decoded_df(
     df: pd.DataFrame,
-    tw: float = DEFAULT_CLUSTER_TW,
-    radius: int = DEFAULT_CLUSTER_RADIUS,
-    energy_calib: np.ndarray = None,
-    timewalk_correct: bool = False,
-    trim_correct: bool = False,
+    tw: float,
+    radius: int,
+    correct_timewalk: bool = False,
 ) -> pd.DataFrame:
-    include_energy = isinstance(energy_calib, np.ndarray)
     # apply gap (needed for correct pixel mapping to energy calibrations)
-    if trim_correct:
-        df = trim_corr(df, trim_correct)
-    cluster_labels, events = cluster(df, tw, radius, include_energy=include_energy)
+    estimate_energy: bool = "e" in df.columns
+    cluster_labels, events = cluster(df, tw, radius, estimate_energy=estimate_energy, correct_timewalk=correct_timewalk)
     df["cluster_id"] = cluster_labels
     cluster_array = group_indices(cluster_labels)
     data = centroid_clusters(
         cluster_array,
         events,
-        include_energy=include_energy,
-        timewalk_correct=timewalk_correct,
+        estimate_energy=estimate_energy,
+        correct_timewalk=correct_timewalk,
     )
 
     return (
-        pd.DataFrame(ingest_cent_data(data, include_energy=include_energy, timewalk_correct=timewalk_correct))
+        pd.DataFrame(ingest_cent_data(data, estimate_energy=estimate_energy, correct_timewalk=correct_timewalk))
         .sort_values(["t", "xc", "yc", "ToT_max", "ToT_sum"])
         .reset_index(drop=True)
     )

--- a/src/tpx3awkward/processing/cluster.py
+++ b/src/tpx3awkward/processing/cluster.py
@@ -5,12 +5,6 @@ import pandas as pd
 TIMESTAMP_VALUE = 1.5625 * 1e-9  # each raw timestamp is 1.5625 nanoseconds
 MICROSECOND = 1e-6
 
-# We have had decent success with these values, but do not know for sure if they are optimal.
-DEFAULT_CLUSTER_RADIUS = 3
-DEFAULT_CLUSTER_TW_MICROSECONDS = 0.3
-
-DEFAULT_CLUSTER_TW = int(DEFAULT_CLUSTER_TW_MICROSECONDS * MICROSECOND / TIMESTAMP_VALUE)
-
 
 def _cluster(df, tw, radius, estimate_energy: bool = False, correct_timewalk: bool = False):
     cols = ["t", "x", "y", "ToT", "t"]

--- a/src/tpx3awkward/processing/config.py
+++ b/src/tpx3awkward/processing/config.py
@@ -1,0 +1,29 @@
+from types import Path
+
+import numpy as np
+from pydantic import BaseModel
+
+from .pipeline import f_type
+
+
+class Tpx3Config(BaseModel):
+    # clustering/centroiding configurations
+    time_window: float
+    radius: float
+
+    # energy estimation configurations
+    estimate_energy: bool
+    energy_estimation_params: np.ndarray | Path
+
+    # timewalk configurations
+    correct_timewalk: bool
+    b: float
+    c: float
+
+    # trim configurations
+    correct_trim: bool
+    trim_mask: np.ndarray | Path
+
+    # misc configurations
+    file_extension: f_type
+    add_centroid_cols: bool

--- a/src/tpx3awkward/processing/config.py
+++ b/src/tpx3awkward/processing/config.py
@@ -1,41 +1,95 @@
 from pathlib import Path
 
 import numpy as np
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+from .cluster import DEFAULT_CLUSTER_TW
 
 
 class Tpx3Config(BaseModel):
+    """
+    Configuration for TPX3 data processing pipeline.
+
+    This includes clustering, corrections, energy estimations, and output formats.
+
+    """
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    # clustering/centroiding configurations
+    # --- Clustering ---
     time_window: float
     radius: float
 
-    # energy estimation configurations
-    estimate_energy: bool
-    energy_estimation_parameters: np.ndarray | Path | str | None
+    # --- Energy estimation ---
+    estimate_energy: bool = False
+    energy_estimation_parameters: np.ndarray | None = None
 
-    # timewalk configurations
-    correct_timewalk: bool
-    b: float
-    c: float
+    # --- Timewalk ---
+    correct_timewalk: bool = False
+    timewalk_b: float | None = None
+    timewalk_c: float | None = None
 
-    # trim configurations
-    correct_trim: bool
-    trim_mask: np.ndarray | Path | str | None
+    # --- Trim correction ---
+    correct_trim: bool = False
+    trim_mask: np.ndarray | None = None
 
-    # misc configurations
+    # --- Misc. ---
     file_extension: str
     add_centroid_cols: bool
+    overwrite: bool
+    verbose: bool = False
 
-    @field_validator("energy_estimation_parameters", mode="after")
+    @field_validator("energy_estimation_parameters", mode="before")
     @classmethod
     def load_energy_estimation_parameters(cls, value: np.ndarray | Path | str):
-        if isinstance(value, np.ndarray):
+        if value is None or isinstance(value, np.ndarray):
             return value
+        if isinstance(value, (str, Path)):
+            path = Path(value)
+            try:
+                return np.load(path)
+            except Exception as e:
+                raise ValueError(f"Failed to load energy estimation parameters with path {path}") from e
+        raise TypeError("energy_estimation_parameters must be a numpy array, a path, or None")
 
-        value = Path(value)
-        try:
-            return np.load(value)
-        except Exception as e:
-            raise ValueError(f"Failed to load energy estimation parameters with path {value}") from e
+    @field_validator("trim_mask", mode="before")
+    @classmethod
+    def load_trim_mask(cls, value: np.ndarray | Path | str):
+        if value is None or isinstance(value, np.ndarray):
+            return value
+        if isinstance(value, (str, Path)):
+            path = Path(value)
+            try:
+                return np.load(path)
+            except Exception as e:
+                raise ValueError(f"Failed to load trim mask with path {path}") from e
+        raise TypeError("trim_mask must be a numpy array, a path, or None")
+
+    @field_validator("file_extension", mode="after")
+    @classmethod
+    def validate_file_extension(cls, value: str):
+        if value not in (".h5", ".parquet"):
+            raise ValueError("file_extension must be one of '.h5' or '.parquet'")
+
+    @model_validator(mode="after")
+    def validate_dependencies(self):
+        if self.estimate_energy and self.energy_estimation_parameters is None:
+            raise ValueError("energy_estimation_parameters must be provided when estimate_energy=True")
+        if self.correct_timewalk and (self.timewalk_b is None or self.timewalk_c is None):
+            raise ValueError("timewalk_b and timewalk_c parameters must be provided when correct_timewalk=True")
+        if self.correct_trim and (self.trim_mask is None):
+            raise ValueError("trim_mask must be provided when correct_trim=True")
+        return self
+
+    @classmethod
+    def from_defaults(cls, **overrides) -> "Tpx3Config":
+        defaults = {
+            "time_window": DEFAULT_CLUSTER_TW,
+            "radius": 3,
+            "file_extension": ".parquet",
+            "add_centroid_cols": True,
+            "overwrite": True,
+        }
+
+        defaults.update(overrides)
+        return cls(**defaults)

--- a/src/tpx3awkward/processing/config.py
+++ b/src/tpx3awkward/processing/config.py
@@ -1,19 +1,19 @@
-from types import Path
+from pathlib import Path
 
 import numpy as np
-from pydantic import BaseModel
-
-from .pipeline import f_type
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class Tpx3Config(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     # clustering/centroiding configurations
     time_window: float
     radius: float
 
     # energy estimation configurations
     estimate_energy: bool
-    energy_estimation_params: np.ndarray | Path
+    energy_estimation_parameters: np.ndarray | Path | str | None
 
     # timewalk configurations
     correct_timewalk: bool
@@ -22,8 +22,20 @@ class Tpx3Config(BaseModel):
 
     # trim configurations
     correct_trim: bool
-    trim_mask: np.ndarray | Path
+    trim_mask: np.ndarray | Path | str | None
 
     # misc configurations
-    file_extension: f_type
+    file_extension: str
     add_centroid_cols: bool
+
+    @field_validator("energy_estimation_parameters", mode="after")
+    @classmethod
+    def load_energy_estimation_parameters(cls, value: np.ndarray | Path | str):
+        if isinstance(value, np.ndarray):
+            return value
+
+        value = Path(value)
+        try:
+            return np.load(value)
+        except Exception as e:
+            raise ValueError(f"Failed to load energy estimation parameters with path {value}") from e

--- a/src/tpx3awkward/processing/config.py
+++ b/src/tpx3awkward/processing/config.py
@@ -14,7 +14,7 @@ class Tpx3Config(BaseModel):
 
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     # --- Clustering ---
     time_window: float
@@ -70,6 +70,7 @@ class Tpx3Config(BaseModel):
     def validate_file_extension(cls, value: str):
         if value not in (".h5", ".parquet"):
             raise ValueError("file_extension must be one of '.h5' or '.parquet'")
+        return value
 
     @model_validator(mode="after")
     def validate_dependencies(self):

--- a/src/tpx3awkward/processing/config.py
+++ b/src/tpx3awkward/processing/config.py
@@ -3,8 +3,6 @@ from pathlib import Path
 import numpy as np
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
-from .cluster import DEFAULT_CLUSTER_TW
-
 
 class Tpx3Config(BaseModel):
     """
@@ -85,7 +83,7 @@ class Tpx3Config(BaseModel):
     @classmethod
     def from_defaults(cls, **overrides) -> "Tpx3Config":
         defaults = {
-            "time_window": DEFAULT_CLUSTER_TW,
+            "time_window": 0.3,
             "radius": 3,
             "file_extension": ".parquet",
             "add_centroid_cols": True,

--- a/src/tpx3awkward/processing/corrections.py
+++ b/src/tpx3awkward/processing/corrections.py
@@ -56,12 +56,12 @@ def trim_corr(df: pd.DataFrame, total_mask: np.ndarray) -> None:
 
 
 @numba.njit(cache=True, fastmath=True)
-def timewalk_corr_exp(ToT, b=167.0, c=-0.016):
-    return np.uint64(np.rint(b * np.exp(c * ToT) / 1.5625))
+def timewalk_corr_exp(ToT, b, c):
+    return np.rint(b * np.exp(c * ToT) / 1.5625).astype(np.uint64)
 
 
-def timewalk_corr(t, tot, b=167.0, c=-0.016) -> None:
-    """Applies timewalk correction in place."""
+@numba.njit(cache=True)
+def timewalk_corr(t, tot, b, c) -> np.array:
     return t - timewalk_corr_exp(tot, b, c)
 
 

--- a/src/tpx3awkward/processing/files.py
+++ b/src/tpx3awkward/processing/files.py
@@ -1,9 +1,14 @@
+import json
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from .config import Tpx3Config
 
 f_type = SimpleNamespace(HDF=".h5", PARQUET=".parquet")
 
@@ -117,7 +122,7 @@ def converted_path(filepath: str | Path, extension: str = f_type.PARQUET, cent: 
     return Path(out_path.replace(".tpx3", f"{'_cent' if cent else ''}{extension}"))
 
 
-def save_df(df: pd.DataFrame, fpath: str | Path):
+def save_df(df: pd.DataFrame, fpath: str | Path, config: Tpx3Config | None = None):
     """
     Save a Pandas DataFrame to a parquet file, ensuring that all necessary directories exist.
 
@@ -138,13 +143,30 @@ def save_df(df: pd.DataFrame, fpath: str | Path):
         case f_type.HDF:
             df.to_hdf(fpath, key="df", format="table", mode="w")
         case f_type.PARQUET:
-            df.to_parquet(
-                fpath,
-                engine="pyarrow",
-                index=False,  # important: do not rely on pandas index
-                compression="snappy",
-            )
+            if config:
+                table = pa.Table.from_pandas(df)
+                metadata = dict(table.schema.metadata)
+                config = dict(config)
+                config["energy_estimation_parameters"] = True
+                metadata[b"config"] = json.dumps(config).encode()
+                table = table.replace_schema_metadata(metadata)
+                pq.write_table(table, fpath, compression="snappy")
+            else:
+                df.to_parquet(
+                    fpath,
+                    engine="pyarrow",
+                    index=False,  # important: do not rely on pandas index
+                    compression="snappy",
+                )
         case _:
             raise TypeError(f"unknown/unimplemented file type: {fpath.suffix}")
 
     # df.to_hdf(fpath, key="df", format="table", mode="w")
+
+
+def read_parquet_config(fpath: Path | str):
+    fpath = Path(fpath)
+
+    table = pq.read_table(fpath)
+    metadata = table.schema.metadata
+    return json.loads(metadata.get(b"config", b"{}"))

--- a/src/tpx3awkward/processing/files.py
+++ b/src/tpx3awkward/processing/files.py
@@ -1,5 +1,5 @@
 import json
-import warnings
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -11,6 +11,7 @@ from numpy.typing import NDArray
 
 from .config import Tpx3Config
 
+logger = logging.getLogger(__name__)
 f_type = SimpleNamespace(HDF=".h5", PARQUET=".parquet")
 
 
@@ -125,7 +126,7 @@ def converted_path(filepath: str | Path, extension: str = f_type.PARQUET, cent: 
         out_path = str(filepath).replace("/assets/", "/Compressed_Data/")
     else:
         if "/nsls2/data/chx/legacy/" not in str(filepath):
-            warnings.warn(
+            logger.info(
                 "unexpected file path used, operation will proceed but it is suggested to confirm correct target directory",
                 stacklevel=2,
             )

--- a/src/tpx3awkward/processing/files.py
+++ b/src/tpx3awkward/processing/files.py
@@ -161,7 +161,7 @@ def save_df(df: pd.DataFrame, fpath: str | Path, config: Tpx3Config | None = Non
                 table = pa.Table.from_pandas(df)
                 metadata = dict(table.schema.metadata)
                 config = dict(config)
-                config["energy_estimation_parameters"] = True
+                config["energy_estimation_parameters"] = None
                 metadata[b"config"] = json.dumps(config).encode()
                 table = table.replace_schema_metadata(metadata)
                 pq.write_table(table, fpath, compression="snappy")
@@ -174,8 +174,6 @@ def save_df(df: pd.DataFrame, fpath: str | Path, config: Tpx3Config | None = Non
                 )
         case _:
             raise TypeError(f"unknown/unimplemented file type: {fpath.suffix}")
-
-    # df.to_hdf(fpath, key="df", format="table", mode="w")
 
 
 def read_parquet_config(fpath: Path | str):

--- a/src/tpx3awkward/processing/pipeline.py
+++ b/src/tpx3awkward/processing/pipeline.py
@@ -3,33 +3,26 @@ import logging
 import multiprocessing
 from functools import partial
 from pathlib import Path
-from types import SimpleNamespace
 
 import numpy as np
 from tqdm import tqdm
 
-from .cluster import DEFAULT_CLUSTER_RADIUS, DEFAULT_CLUSTER_TW, cluster_raw_df
+from .cluster import cluster_decoded_df
 from .config import Tpx3Config
+from .corrections import estimate_energies
 from .decoding import decode_tpx3_binary
-from .files import converted_path, raw_as_numpy, save_df, trim_corr_file
-from .schemas import empty_cent_df, empty_raw_df
+from .files import converted_path, f_type, raw_as_numpy, save_df, trim_corr_file
+from .schemas import empty_cent_df
 
 logger = logging.getLogger(__name__)
-f_type = SimpleNamespace(HDF=".h5", PARQUET=".parquet")
 
 
 def convert_tpx3_file(
     tpx3_fpath: str | Path,
-    config: Tpx3Config = None,
-    extension: str = f_type.PARQUET,
+    *,
     output_dir: str | Path | None = None,
-    tw: float = DEFAULT_CLUSTER_TW,
-    radius: int = DEFAULT_CLUSTER_RADIUS,
-    energy_calib: np.ndarray | None = None,
-    timewalk_correct: bool = False,
-    trim_correct: bool = False,
-    print_details: bool = False,
-    overwrite: bool = True,
+    config: Tpx3Config | None = None,
+    **overrides,
 ):
     """
     Convert a .tpx3 file into raw and centroided Pandas dataframes, which are stored in .h5 files.
@@ -38,24 +31,10 @@ def convert_tpx3_file(
     ----------
     tpx3_fpath : str | Path
         .tpx3 file path
-    extension: str = ".parquet"
-        type of file format (.h5 , .parquet) to export to. Can use internal f_type namespace to alias
-    output_dir: str | Path | None = None
+    output_dir : str | Path | None = None
         Directory to save converted files to. Will save to same directory as file if None
-    tw : float = DEFAULT_CLUSTER_TW_MICROSECONDS
-        The time window, in Timepix timestamp units, to perform centroiding
-    radius : int = DEFAULT_CLUSTER_RADIUS
-        The radius, in pixels, to perform centroiding
-    trim_correct : bool = False
-        Whether to apply trim correction
-    timewalk_correct : bool = False
-        Whether to apply timewalk correction
-    print_details : bool = False
-        Boolean toggle about whether to print detailed data.
-    overwrite : bool = True
-        Boolean toggle about whether to overwrite pre-existing data.
-    energy_calib: np.ndarray = None
-        numpy array of dimension (514, 514, 4) and type float64 that contains the parameters to the E(ToT) function
+    config : Tpx3Config | None = None
+        Defines the configurations for processing, considered the ground truth and overrides any kwargs
 
     Raises
     ------
@@ -64,8 +43,12 @@ def convert_tpx3_file(
     ValueError
         If the file doesn't have `.tpx3` suffix
     """
+    if config is not None and overrides:
+        raise ValueError("Pass either `config` or keyword overrides, not both.")
+    if config is None:
+        config = Tpx3Config.from_defaults(**overrides)
 
-    if print_details:
+    if config.verbose:
         logger.setLevel(logging.INFO)
     else:
         logger.setLevel(logging.WARNING)
@@ -77,50 +60,69 @@ def convert_tpx3_file(
     if tpx3_fpath.suffix != ".tpx3":
         raise ValueError(f"{tpx3_fpath} is not a .tpx3 file")
 
-    out_fpath = converted_path(tpx3_fpath, extension=extension, cent=False)
-    cent_out_fpath = converted_path(tpx3_fpath, extension=extension, cent=True)
+    out_fpath = converted_path(tpx3_fpath, extension=config.file_extension, cent=False)
+    cent_out_fpath = converted_path(tpx3_fpath, extension=config.file_extension, cent=True)
 
     if output_dir:
         output_dir = Path(output_dir)
+        if output_dir.exists() and not output_dir.is_dir():
+            raise ValueError(f"{output_dir} exists but is not a directory.")
+        output_dir.mkdir(
+            parents=True, exist_ok=True
+        )  # TODO should we be doing this? compare with what sophy and/or pymepix does
         out_fpath = output_dir / out_fpath.name
         cent_out_fpath = output_dir / cent_out_fpath.name
 
     have_df = out_fpath.exists()  # Check if dfname exists
     have_dfc = cent_out_fpath.exists()  # Check if dfcname exists
 
-    if have_df and have_dfc and not overwrite:
-        print(f"-> {tpx3_fpath.name} already processed, skipping.")
+    if have_df and have_dfc and not config.overwrite:
+        logger.info(f"-> {tpx3_fpath.name} already processed, skipping.")
         return False
 
     logger.info(f"-> Processing {tpx3_fpath.name}, size: {tpx3_fpath.stat().st_size / (1024 * 1024):.1f} MB")
-    df = decode_tpx3_binary(raw_as_numpy(tpx3_fpath))
-    num_events = df.shape[0]
+    decoded_df = decode_tpx3_binary(raw_as_numpy(tpx3_fpath))
+    num_events = decoded_df.shape[0]
 
     if num_events == 0:
         logger.info("No events found! Saving empty dataframes.")
-        include_energy = isinstance(energy_calib, np.ndarray)
-        save_df(empty_raw_df(include_energy=include_energy), out_fpath)
-        save_df(empty_cent_df(include_energy=include_energy), cent_out_fpath)
+        save_df(
+            empty_cent_df(estimate_energy=config.estimate_energy, correct_timewalk=config.correct_timewalk), cent_out_fpath
+        )
         gc.collect()
         return True
 
     logger.info(f"Loading {tpx3_fpath.name} complete. {num_events} events found.")
 
-    cdf = cluster_raw_df(
-        df,
-        tw,
-        radius,
-        energy_calib=energy_calib,
-        timewalk_correct=timewalk_correct,
-        trim_correct=trim_correct,
+    if config.estimate_energy:
+        decoded_df["e"] = estimate_energies(
+            decoded_df["x"].to_numpy(),
+            decoded_df["y"].to_numpy(),
+            decoded_df["ToT"].to_numpy(),
+            config.energy_estimation_parameters,
+        )
+    # if config.correct_timewalk:
+    # decoded_df['t_corr'] = timewalk_corr(decoded_df['t'].to_numpy(),
+    # decoded_df['ToT'].to_numpy(), b=config.timewalk_b, c=config.timewalk_c)
+
+    if config.correct_trim:
+        ...
+
+    clustered_df = cluster_decoded_df(
+        decoded_df,
+        config.time_window,
+        config.radius,
+        energy_calib=config.energy_estimation_parameters,
+        timewalk_correct=config.correct_timewalk,
+        trim_correct=config.correct_trim,
     )
     # maybe we should put this somewhere else...
-    cdf.loc[cdf["xc"] >= 255.5, "xc"] += 2
-    cdf.loc[cdf["yc"] >= 255.5, "yc"] += 2
+    clustered_df.loc[clustered_df["xc"] >= 255.5, "xc"] += 2
+    clustered_df.loc[clustered_df["yc"] >= 255.5, "yc"] += 2
 
     logger.info(f"Clustering and centroiding complete. Saving to {cent_out_fpath.name}...")
 
-    save_df(cdf, cent_out_fpath, config=config)
+    save_df(clustered_df, cent_out_fpath, config=config)
     logger.info(f"Saving {cent_out_fpath.name} complete. Checking file existence...")
 
     if cent_out_fpath.exists():
@@ -130,8 +132,7 @@ def convert_tpx3_file(
         logger.info(f"WARNING: {cent_out_fpath.name} doesn't exist but it should?!")
         to_return = False
 
-    logger.info("Moving onto next file...")
-    del df, cdf
+    del decoded_df, clustered_df
     gc.collect()
     return to_return
 

--- a/src/tpx3awkward/processing/pipeline.py
+++ b/src/tpx3awkward/processing/pipeline.py
@@ -10,6 +10,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from .cluster import DEFAULT_CLUSTER_RADIUS, DEFAULT_CLUSTER_TW, cluster_raw_df
+from .config import Tpx3Config
 from .decoding import tpx_to_raw_df
 from .files import converted_path, save_df, trim_corr_file
 from .schemas import empty_cent_df, empty_raw_df
@@ -37,6 +38,7 @@ def drop_zero_tot(df: pd.DataFrame) -> pd.DataFrame:
 
 def convert_tpx3_file(
     tpx3_fpath: str | Path,
+    config: Tpx3Config = None,
     extension: str = f_type.PARQUET,
     output_dir: str | Path | None = None,
     tw: float = DEFAULT_CLUSTER_TW,
@@ -56,7 +58,9 @@ def convert_tpx3_file(
     ----------
     tpx3_fpath : Union[str, Path]
         .tpx3 file path
-    extension: str
+    config: Tpx3Config = None
+        Configuration settings for data processing
+    extension: str = '.parquet'
         type of file format (.h5 , .parquet) to export to. Can use internal f_type namespace to alias
     tw : float = DEFAULT_CLUSTER_TW_MICROSECONDS
         The time window, in Timepix timestamp units, to perform centroiding
@@ -128,7 +132,7 @@ def convert_tpx3_file(
 
                     logger.info(f"Clustering and centroiding complete. Saving to {cent_out_fpath.name}...")
 
-                    save_df(cdf, cent_out_fpath)
+                    save_df(cdf, cent_out_fpath, config=config)
                     logger.info(f"Saving {cent_out_fpath.name} complete. Checking file existence...")
 
                     if cent_out_fpath.exists():

--- a/src/tpx3awkward/processing/pipeline.py
+++ b/src/tpx3awkward/processing/pipeline.py
@@ -4,14 +4,13 @@ import multiprocessing
 from functools import partial
 from pathlib import Path
 
-import numpy as np
 from tqdm import tqdm
 
 from .cluster import cluster_decoded_df
 from .config import Tpx3Config
-from .corrections import estimate_energies
+from .corrections import estimate_energies, timewalk_corr, trim_corr
 from .decoding import decode_tpx3_binary
-from .files import converted_path, f_type, raw_as_numpy, save_df, trim_corr_file
+from .files import converted_path, raw_as_numpy, save_df
 from .schemas import empty_cent_df
 
 logger = logging.getLogger(__name__)
@@ -32,9 +31,11 @@ def convert_tpx3_file(
     tpx3_fpath : str | Path
         .tpx3 file path
     output_dir : str | Path | None = None
-        Directory to save converted files to. Will save to same directory as file if None
+        Directory to save converted files to. Will save to the same directory as file if None
     config : Tpx3Config | None = None
-        Defines the configurations for processing, considered the ground truth and overrides any kwargs
+        Defines the configurations for processing. If None, then will use `Tpx3Config.from_defaults` with overrides
+    **overrides
+        Used when config is None to override default parameters.
 
     Raises
     ------
@@ -101,20 +102,20 @@ def convert_tpx3_file(
             decoded_df["ToT"].to_numpy(),
             config.energy_estimation_parameters,
         )
-    # if config.correct_timewalk:
-    # decoded_df['t_corr'] = timewalk_corr(decoded_df['t'].to_numpy(),
-    # decoded_df['ToT'].to_numpy(), b=config.timewalk_b, c=config.timewalk_c)
+
+    if config.correct_timewalk:
+        decoded_df["t_corr"] = timewalk_corr(
+            decoded_df["t"].to_numpy(), decoded_df["ToT"].to_numpy(), config.timewalk_b, config.timewalk_c
+        )
 
     if config.correct_trim:
-        ...
+        decoded_df = trim_corr(decoded_df, config.trim_mask)
 
     clustered_df = cluster_decoded_df(
         decoded_df,
         config.time_window,
         config.radius,
-        energy_calib=config.energy_estimation_parameters,
-        timewalk_correct=config.correct_timewalk,
-        trim_correct=config.correct_trim,
+        correct_timewalk=config.correct_timewalk,
     )
     # maybe we should put this somewhere else...
     clustered_df.loc[clustered_df["xc"] >= 255.5, "xc"] += 2
@@ -138,54 +139,38 @@ def convert_tpx3_file(
 
 
 def convert_tpx3_files(
-    fpaths: list[str] | list[Path],
-    extension: str = f_type.PARQUET,
+    tpx3_fpaths: list[str] | list[Path],
+    *,
     output_dir: str | Path | None = None,
-    trim_correct: str | Path | None = None,
-    print_details: bool = True,
-    energy_calib: np.ndarray | str | Path | None = None,
-    **kwargs,
+    config: Tpx3Config | None = None,
+    **overrides,
 ):
     """
-    Convert a list of .tpx3 files in a single process using convert_tpx3_file().
+    Convert a list of .tpx3 files in a single process using convert_tpx3_file(), catching any errors.
 
     Parameters
     ----------
-    fpaths : Union[List[str], List[Path]]
-        List of .tpx3 file paths to process.
-    extension: str
-        type of file format (.h5 , .parquet) to export to. Can use internal f_type namespace to alias
-    trim_mask_fpath : str, optional
-        Path to the trim correction mask. If None, no correction is applied.
-    print_details : bool, optional
-        Boolean toggle about whether to print detailed data. Default is True.
-    **kwargs : dict
-        Additional keyword arguments passed to `convert_tpx3_file()`.
+    tpx3_fpaths : list[str] | list[Path]
+        .tpx3 file paths
+    output_dir : str | Path | None = None
+        Directory to save converted files to. Will save to the same directory as file if None
+    config : Tpx3Config | None = None
+        Defines the configurations for processing. If None, then will use `Tpx3Config.from_defaults` with overrides
+    **overrides
+        Used when config is None to override default parameters.
     """
-    # Load the mask once (only if provided)
-    trim_mask = trim_corr_file(trim_correct)
-
-    # Load energy estimation params
-    if isinstance(energy_calib, (str, Path)):
-        try:
-            energy_calib = np.load(energy_calib)
-        except Exception:
-            print("Failed to load calibration: {e}")
+    # create config here so it is only done once
+    if config is not None and overrides:
+        raise ValueError("Pass either `config` or keyword overrides, not both.")
+    if config is None:
+        config = Tpx3Config.from_defaults(**overrides)
 
     # Process files sequentially with tqdm progress bar
-    for fpath in tqdm(fpaths, desc="Processing files"):
+    for tpx3_fpath in tqdm(tpx3_fpaths, desc="Processing files"):
         try:
-            convert_tpx3_file(
-                fpath,
-                extension=extension,
-                output_dir=output_dir,
-                trim_correct=trim_mask,
-                print_details=print_details,
-                energy_calib=energy_calib,
-                **kwargs,
-            )
+            convert_tpx3_file(tpx3_fpath, output_dir=output_dir, config=config)
         except Exception:  # noqa: PERF203
-            logger.exception(f"Failed to process {fpath}")
+            logger.exception(f"Failed to process {tpx3_fpath}")
 
 
 def convert_tpx3_file_worker(fpath, **kwargs):
@@ -199,73 +184,53 @@ def convert_tpx3_file_worker(fpath, **kwargs):
 
 
 def convert_tpx3_files_parallel(
-    fpaths: list[str] | list[Path],
-    extension=f_type.PARQUET,
+    tpx3_fpaths: list[str] | list[Path],
+    *,
     output_dir: str | Path | None = None,
+    config: Tpx3Config | None = None,
     num_workers: int | None = None,
-    trim_correct: str | Path | None = None,
-    energy_calib: np.ndarray | str | Path | None = None,
-    **kwargs,
+    **overrides,
 ):
     """
     Convert a list of .tpx3 files in parallel using multiprocessing and convert_tpx3_file().
 
     Parameters
     ----------
-    fpaths : Union[List[str], List[Path]]
-        List of .tpx3 file paths to process.
-    extension: str
-        type of file format (.h5 , .parquet) to export to. Can use internal f_type namespace to alias
-    num_workers : int, optional
-        Number of worker processes to use. Defaults to (CPU count - 4) to leave room for other tasks.
-    trim_mask_fpath : str, optional
-        Path to the trim correction mask. If None, no correction is applied.
-    energy_calib_fpath: np.ndarray = None
-        fpath pointing to energy estimation parameters array saved as .npy file.
-        if not specified then energy won't be estimated.
-    **kwargs : dict
-        Additional keyword arguments passed to `convert_tpx3_file()`.
+    tpx3_fpaths : list[str] | list[Path]
+        .tpx3 file paths
+    output_dir : str | Path | None = None
+        Directory to save converted files to. Will save to the same directory as file if None
+    config : Tpx3Config | None = None
+        Defines the configurations for processing. If None, then will use `Tpx3Config.from_defaults` with overrides
+    num_workers : int | None = None
+        Number of worker processes to use. Defaults to max(1, (CPU count - 4)) to leave room for other tasks.
+    **overrides
+        Used when config is None to override default parameters.
     """
-    if len(fpaths) > 0:
-        if num_workers is None:
-            max_workers = min(multiprocessing.cpu_count() - 4, len(fpaths))  # Leave 4 cores free
-        else:
-            max_workers = min(num_workers, len(fpaths))  # Don't use more workers than files
+    # create config here so it is only done once
+    if config is not None and overrides:
+        raise ValueError("Pass either `config` or keyword overrides, not both.")
+    if config is None:
+        config = Tpx3Config.from_defaults(**overrides)
 
-        max_workers = max(max_workers, 1)
+    if num_workers is None:
+        max_workers = min(multiprocessing.cpu_count() - 4, len(tpx3_fpaths))  # Leave 4 cores free
+    else:
+        max_workers = min(num_workers, len(tpx3_fpaths))  # Don't use more workers than files
 
-        # Load the mask once
-        trim_mask = trim_corr_file(trim_correct)
+    max_workers = max(max_workers, 1)
 
-        # Load energy estimation params
-        if isinstance(energy_calib, (str, Path)):
-            try:
-                energy_calib = np.load(energy_calib)
-            except Exception as e:
-                print(f"Failed to load calibration: {e}")
+    worker_func = partial(convert_tpx3_file_worker, output_dir=output_dir, config=config)
 
-        # Pass the preloaded mask to all workers
-        worker_func = partial(
-            convert_tpx3_file_worker,
-            extension=extension,
-            output_dir=output_dir,
-            trim_correct=trim_mask,
-            energy_calib=energy_calib,
-            **kwargs,
+    with multiprocessing.Pool(processes=max_workers) as pool:
+        results = list(
+            tqdm(
+                pool.imap_unordered(worker_func, tpx3_fpaths),
+                total=len(tpx3_fpaths),
+                desc="Processing files",
+            )
         )
 
-        with multiprocessing.Pool(processes=max_workers) as pool:
-            results = list(
-                tqdm(
-                    pool.imap_unordered(worker_func, fpaths),
-                    total=len(fpaths),
-                    desc="Processing files",
-                )
-            )
-
-        # Count successes
-        num_true = sum(results)
-    else:
-        num_true = 0
-
-    print(f"Successfully converted {num_true} out of {len(fpaths)}!")
+    # Count successes
+    num_true = sum(results)
+    print(f"Successfully converted {num_true} out of {len(tpx3_fpaths)}!")

--- a/src/tpx3awkward/processing/pipeline.py
+++ b/src/tpx3awkward/processing/pipeline.py
@@ -29,7 +29,7 @@ def convert_tpx3_file(
     Parameters
     ----------
     tpx3_fpath : str | Path
-        .tpx3 file path
+        Path to a `.tpx3` file
     output_dir : str | Path | None = None
         Directory to save converted files to. Will save to the same directory as file if None
     config : Tpx3Config | None = None
@@ -74,10 +74,7 @@ def convert_tpx3_file(
         out_fpath = output_dir / out_fpath.name
         cent_out_fpath = output_dir / cent_out_fpath.name
 
-    have_df = out_fpath.exists()  # Check if dfname exists
-    have_dfc = cent_out_fpath.exists()  # Check if dfcname exists
-
-    if have_df and have_dfc and not config.overwrite:
+    if out_fpath.exists() and cent_out_fpath.exists() and not config.overwrite:
         logger.info(f"-> {tpx3_fpath.name} already processed, skipping.")
         return False
 
@@ -115,7 +112,6 @@ def convert_tpx3_file(
         decoded_df,
         config.time_window,
         config.radius,
-        correct_timewalk=config.correct_timewalk,
     )
     # maybe we should put this somewhere else...
     clustered_df.loc[clustered_df["xc"] >= 255.5, "xc"] += 2

--- a/src/tpx3awkward/processing/schemas.py
+++ b/src/tpx3awkward/processing/schemas.py
@@ -35,7 +35,7 @@ def empty_raw_df(include_energy: bool = False) -> pd.DataFrame:
     return pd.DataFrame(data)
 
 
-def empty_cent_df(include_energy: bool = False, timewalk_correct: bool = True) -> pd.DataFrame:
+def empty_cent_df(estimate_energy: bool = False, correct_timewalk: bool = False) -> pd.DataFrame:
     """
     Create an empty DataFrame with the expected columns from ingest_cent_data()
     and the specified data types.
@@ -60,9 +60,9 @@ def empty_cent_df(include_energy: bool = False, timewalk_correct: bool = True) -
         "n": np.array([], dtype="u1"),  # uint8 (ubyte)
     }
 
-    if include_energy:
+    if estimate_energy:
         data["e_sum"] = np.array([], dtype="float32")
-    if timewalk_correct:
+    if correct_timewalk:
         data["t_corr"] = np.array([], dtype="uint64")
 
     return pd.DataFrame(data)

--- a/tests/configs/tpx3_configurations.yaml
+++ b/tests/configs/tpx3_configurations.yaml
@@ -1,20 +1,21 @@
-# clustering/centroiding configurations
+# --- Clustering ---
 time_window: 0.3
 radius: 3
 
-# energy estimation configurations
+# --- Energy estimation ---
 estimate_energy: True
 energy_estimation_parameters: "tests/configs/energy_estimation_test_parameters.npy"
 
-# timewalk configurations
+# --- Timewalk ---
 correct_timewalk: True
-b: 167.0
-c: -0.016
+timewalk_b: 167.0
+timewalk_c: -0.016
 
-# trim configurations
+# --- Trim correction ---
 correct_trim: False
-trim_mask: None
 
-# misc configurations
+# --- Misc. ---
 file_extension: ".parquet"
 add_centroid_cols: True
+overwrite: True
+verbose: True

--- a/tests/configs/tpx3_configurations.yaml
+++ b/tests/configs/tpx3_configurations.yaml
@@ -1,0 +1,20 @@
+# clustering/centroiding configurations
+time_window: 0.3
+radius: 3
+
+# energy estimation configurations
+estimate_energy: True
+energy_estimation_parameters: "tests/configs/energy_estimation_test_parameters.npy"
+
+# timewalk configurations
+correct_timewalk: True
+b: 167.0
+c: -0.016
+
+# trim configurations
+correct_trim: False
+trim_mask: None
+
+# misc configurations
+file_extension: ".parquet"
+add_centroid_cols: True

--- a/tests/processing/test_pipeline.py
+++ b/tests/processing/test_pipeline.py
@@ -3,8 +3,9 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+import yaml
 
-from tpx3awkward import convert_tpx3_file, convert_tpx3_files, convert_tpx3_files_parallel
+from tpx3awkward import Tpx3Config, convert_tpx3_file, convert_tpx3_files, convert_tpx3_files_parallel, read_parquet_config
 
 DATA_DIR = Path(__file__).parents[1] / "data"
 CONFIG_DIR = Path(__file__).parents[1] / "configs"
@@ -12,7 +13,7 @@ CONFIG_DIR = Path(__file__).parents[1] / "configs"
 
 @pytest.mark.filterwarnings("ignore")
 def test_convert_tpx3_file(tmp_path):
-    path_to_data = DATA_DIR / "raw_test_data_00.tpx3"
+    path_to_data = DATA_DIR / "raw_test_data_01.tpx3"
     path_to_energy_parameters = CONFIG_DIR / "energy_estimation_test_parameters.npy"
     energy_estimation_test_parameters = np.load(path_to_energy_parameters)
     convert_tpx3_file(
@@ -23,9 +24,35 @@ def test_convert_tpx3_file(tmp_path):
         print_details=True,
     )
 
-    cdf = pd.read_parquet(tmp_path / "raw_test_data_00_cent.parquet")
+    cdf = pd.read_parquet(tmp_path / "raw_test_data_01_cent.parquet")
     required = {"t", "xc", "yc", "ToT_max", "ToT_sum", "n", "e_sum", "t_corr"}
     assert required.issubset(cdf.columns)
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_convert_tpx3_file_config(tmp_path):
+    path_to_data = DATA_DIR / "raw_test_data_01.tpx3"
+    path_to_yaml_config = CONFIG_DIR / "tpx3_configurations.yaml"
+    path_to_energy_parameters = CONFIG_DIR / "energy_estimation_test_parameters.npy"
+    energy_estimation_test_parameters = np.load(path_to_energy_parameters)
+
+    with path_to_yaml_config.open() as f:
+        tpx3_config = Tpx3Config.model_validate(yaml.safe_load(f))
+
+    convert_tpx3_file(
+        path_to_data,
+        config=tpx3_config,
+        output_dir=tmp_path,
+        energy_calib=energy_estimation_test_parameters,
+        timewalk_correct=True,
+        print_details=True,
+    )
+    processed_cdf_fpath = tmp_path / "raw_test_data_01_cent.parquet"
+    cdf = pd.read_parquet(processed_cdf_fpath)
+    required = {"t", "xc", "yc", "ToT_max", "ToT_sum", "n", "e_sum", "t_corr"}
+    assert required.issubset(cdf.columns)
+    tpx3_config.energy_estimation_parameters = True
+    assert read_parquet_config(processed_cdf_fpath) == dict(tpx3_config)
 
 
 @pytest.mark.filterwarnings("ignore")

--- a/tests/processing/test_pipeline.py
+++ b/tests/processing/test_pipeline.py
@@ -37,7 +37,8 @@ def test_convert_tpx3_file_config(tmp_path):
     energy_estimation_test_parameters = np.load(path_to_energy_parameters)
 
     with path_to_yaml_config.open() as f:
-        tpx3_config = Tpx3Config.model_validate(yaml.safe_load(f))
+        data = yaml.safe_load(f)
+    tpx3_config = Tpx3Config.model_validate(data)
 
     convert_tpx3_file(
         path_to_data,
@@ -51,7 +52,7 @@ def test_convert_tpx3_file_config(tmp_path):
     cdf = pd.read_parquet(processed_cdf_fpath)
     required = {"t", "xc", "yc", "ToT_max", "ToT_sum", "n", "e_sum", "t_corr"}
     assert required.issubset(cdf.columns)
-    tpx3_config.energy_estimation_parameters = True
+    tpx3_config.energy_estimation_parameters = None
     assert read_parquet_config(processed_cdf_fpath) == dict(tpx3_config)
 
 

--- a/tests/processing/test_pipeline.py
+++ b/tests/processing/test_pipeline.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import pytest
 import yaml
 
 from tpx3awkward import Tpx3Config, convert_tpx3_file, convert_tpx3_files, convert_tpx3_files_parallel, read_parquet_config
@@ -11,7 +10,6 @@ DATA_DIR = Path(__file__).parents[1] / "data"
 CONFIG_DIR = Path(__file__).parents[1] / "configs"
 
 
-@pytest.mark.filterwarnings("ignore")
 def test_convert_tpx3_file(tmp_path):
     path_to_data = DATA_DIR / "raw_test_data_01.tpx3"
     path_to_energy_parameters = CONFIG_DIR / "energy_estimation_test_parameters.npy"
@@ -19,9 +17,12 @@ def test_convert_tpx3_file(tmp_path):
     convert_tpx3_file(
         path_to_data,
         output_dir=tmp_path,
-        energy_calib=energy_estimation_test_parameters,
-        timewalk_correct=True,
-        print_details=True,
+        estimate_energy=True,
+        energy_estimation_parameters=energy_estimation_test_parameters,
+        correct_timewalk=True,
+        timewalk_b=167.0,
+        timewalk_c=-0.016,
+        verbose=True,
     )
 
     cdf = pd.read_parquet(tmp_path / "raw_test_data_01_cent.parquet")
@@ -29,12 +30,9 @@ def test_convert_tpx3_file(tmp_path):
     assert required.issubset(cdf.columns)
 
 
-@pytest.mark.filterwarnings("ignore")
 def test_convert_tpx3_file_config(tmp_path):
     path_to_data = DATA_DIR / "raw_test_data_01.tpx3"
     path_to_yaml_config = CONFIG_DIR / "tpx3_configurations.yaml"
-    path_to_energy_parameters = CONFIG_DIR / "energy_estimation_test_parameters.npy"
-    energy_estimation_test_parameters = np.load(path_to_energy_parameters)
 
     with path_to_yaml_config.open() as f:
         data = yaml.safe_load(f)
@@ -44,9 +42,6 @@ def test_convert_tpx3_file_config(tmp_path):
         path_to_data,
         config=tpx3_config,
         output_dir=tmp_path,
-        energy_calib=energy_estimation_test_parameters,
-        timewalk_correct=True,
-        print_details=True,
     )
     processed_cdf_fpath = tmp_path / "raw_test_data_01_cent.parquet"
     cdf = pd.read_parquet(processed_cdf_fpath)
@@ -56,7 +51,6 @@ def test_convert_tpx3_file_config(tmp_path):
     assert read_parquet_config(processed_cdf_fpath) == dict(tpx3_config)
 
 
-@pytest.mark.filterwarnings("ignore")
 def test_convert_tpx3_files(tmp_path):
     path_to_data = DATA_DIR
     path_to_energy_parameters = CONFIG_DIR / "energy_estimation_test_parameters.npy"
@@ -64,9 +58,12 @@ def test_convert_tpx3_files(tmp_path):
     convert_tpx3_files(
         raw_tpx3_file_paths,
         output_dir=tmp_path,
-        timewalk_correct=True,
-        energy_calib=path_to_energy_parameters,
-        print_details=True,
+        estimate_energy=True,
+        energy_estimation_parameters=path_to_energy_parameters,
+        correct_timewalk=True,
+        timewalk_b=167.0,
+        timewalk_c=-0.016,
+        verbose=True,
     )
 
     for i in range(len(raw_tpx3_file_paths)):
@@ -77,15 +74,15 @@ def test_convert_tpx3_files(tmp_path):
     proc_parquet_files = sorted([p for p in Path(tmp_path).rglob("*") if p.is_file() and "cent.parquet" in str(p)])
     cur_proc_df = pd.concat([pd.read_parquet(f) for f in proc_parquet_files], ignore_index=True)
 
-    # TODO remove this part when we are more confident in the refactor. This processing data is from the old tpx3awkward, and
+    # TODO remove this part when we are more confident in the refactor.
+    # This processing data is from the old tpx3awkward, and
     # is being used as a "stable" output to compare against.
     path_to_proc_data = DATA_DIR / "processed_concat_test_data.parquet"
     stable_proc_df = pd.read_parquet(path_to_proc_data)
 
-    pd.testing.assert_frame_equal(cur_proc_df, stable_proc_df, atol=0.5)
+    pd.testing.assert_frame_equal(cur_proc_df, stable_proc_df, atol=0.01)
 
 
-@pytest.mark.filterwarnings("ignore")
 def test_convert_tpx3_files_parallel(tmp_path):
     path_to_data = DATA_DIR
     path_to_energy_parameters = CONFIG_DIR / "energy_estimation_test_parameters.npy"
@@ -93,9 +90,12 @@ def test_convert_tpx3_files_parallel(tmp_path):
     convert_tpx3_files_parallel(
         raw_tpx3_file_paths,
         output_dir=tmp_path,
-        timewalk_correct=True,
-        energy_calib=path_to_energy_parameters,
-        print_details=True,
+        estimate_energy=True,
+        energy_estimation_parameters=path_to_energy_parameters,
+        correct_timewalk=True,
+        timewalk_b=167.0,
+        timewalk_c=-0.016,
+        verbose=True,
     )
 
     for i in range(len(raw_tpx3_file_paths)):
@@ -106,9 +106,10 @@ def test_convert_tpx3_files_parallel(tmp_path):
     proc_parquet_files = sorted([p for p in Path(tmp_path).rglob("*") if p.is_file() and "cent.parquet" in str(p)])
     cur_proc_df = pd.concat([pd.read_parquet(f) for f in proc_parquet_files], ignore_index=True)
 
-    # TODO remove this part when we are more confident in the refactor. This processing data is from the old tpx3awkward, and
+    # TODO remove this part when we are more confident in the refactor.
+    # This processing data is from the old tpx3awkward, and
     # is being used as a "stable" output to compare against.
     path_to_proc_data = DATA_DIR / "processed_concat_test_data.parquet"
     stable_proc_df = pd.read_parquet(path_to_proc_data)
 
-    pd.testing.assert_frame_equal(cur_proc_df, stable_proc_df, atol=0.5)
+    pd.testing.assert_frame_equal(cur_proc_df, stable_proc_df, atol=0.01)


### PR DESCRIPTION
This PR enables configurations to be the primary way to set parameters for pipeline functions. 

Before, such functions had massive signatures which made them difficult to call as a user, and didn't lend itself well to strong type enforcement within the function.

This PR introduces an instance of Pydantic BaseModel `Tpx3Config`, which contains all the parameters a user would configure to process timepix3 data. When used with pipeline functions, this configuration is also eventually saved as metadata in parquet files for future reference.