### PR TITLE
Sort by corrected timestamp if it exists in centroided data.

### DIFF
--- a/src/tpx3awkward/processing/cluster.py
+++ b/src/tpx3awkward/processing/cluster.py
@@ -139,7 +139,7 @@ def _centroid_clusters(
 
 
 def _ingest_cent_data(
-    data: np.ndarray, estimate_energy: bool = False, correct_timewalk: bool = False
+    data: tuple[np.ndarray], estimate_energy: bool = False, correct_timewalk: bool = False
 ) -> dict[str, np.ndarray]:
     """
     Package np.ndarray into a dict with keys associated with the names of the columns dataframe.
@@ -184,7 +184,7 @@ def cluster_decoded_df(
         Decoded dataframe with columns ['x', 'y', 'ToT', 't', 'chip'].
         May also include optional columns 'e' and 't_corr'.
     tw : float
-        Time Window for the clustering algorithm, in microseconds.
+        Time window for the clustering algorithm, in microseconds.
     radius : int,
         Radius for the clustering algorithm, in pixels.
 
@@ -211,16 +211,8 @@ def cluster_decoded_df(
         correct_timewalk=correct_timewalk,
     )
 
-    if correct_timewalk:
-        return (
-            pd.DataFrame(_ingest_cent_data(data, estimate_energy=estimate_energy, correct_timewalk=correct_timewalk))
-            .sort_values(["t_corr", "t", "xc", "yc", "ToT_max", "ToT_sum"])
-            .reset_index(drop=True)
-        )
-
-    else:
-        return (
-            pd.DataFrame(_ingest_cent_data(data, estimate_energy=estimate_energy, correct_timewalk=correct_timewalk))
-            .sort_values(["t", "xc", "yc", "ToT_max", "ToT_sum"])
-            .reset_index(drop=True)
-        )        
+    return (
+        pd.DataFrame(_ingest_cent_data(data, estimate_energy=estimate_energy, correct_timewalk=correct_timewalk))
+        .sort_values((["t_corr", "t"] if correct_timewalk else ["t"]) + ["xc", "yc", "ToT_max", "ToT_sum"])
+        .reset_index(drop=True)
+    )

--- a/src/tpx3awkward/processing/cluster.py
+++ b/src/tpx3awkward/processing/cluster.py
@@ -211,8 +211,16 @@ def cluster_decoded_df(
         correct_timewalk=correct_timewalk,
     )
 
-    return (
-        pd.DataFrame(_ingest_cent_data(data, estimate_energy=estimate_energy, correct_timewalk=correct_timewalk))
-        .sort_values(["t", "xc", "yc", "ToT_max", "ToT_sum"])
-        .reset_index(drop=True)
-    )
+    if correct_timewalk:
+        return (
+            pd.DataFrame(_ingest_cent_data(data, estimate_energy=estimate_energy, correct_timewalk=correct_timewalk))
+            .sort_values(["t_corr", "t", "xc", "yc", "ToT_max", "ToT_sum"])
+            .reset_index(drop=True)
+        )
+
+    else:
+        return (
+            pd.DataFrame(_ingest_cent_data(data, estimate_energy=estimate_energy, correct_timewalk=correct_timewalk))
+            .sort_values(["t", "xc", "yc", "ToT_max", "ToT_sum"])
+            .reset_index(drop=True)
+        )        

--- a/src/tpx3awkward/processing/cluster.py
+++ b/src/tpx3awkward/processing/cluster.py
@@ -96,7 +96,7 @@ def _centroid_clusters(
     col_indices: np.array,
     estimate_energy: bool = False,
     correct_timewalk: bool = False,
-) -> tuple[np.ndarray]:
+) -> tuple[np.ndarray, ...]:
     num_clusters = cluster_arr.shape[0]
     max_cluster = cluster_arr.shape[1]
     t = np.zeros(num_clusters, dtype="uint64")
@@ -139,14 +139,14 @@ def _centroid_clusters(
 
 
 def _ingest_cent_data(
-    data: tuple[np.ndarray], estimate_energy: bool = False, correct_timewalk: bool = False
+    data: tuple[np.ndarray, ...], estimate_energy: bool = False, correct_timewalk: bool = False
 ) -> dict[str, np.ndarray]:
     """
     Package np.ndarray into a dict with keys associated with the names of the columns dataframe.
 
     Parameters
     ----------
-    data : np.ndarray
+    data : tuple[np.ndarray, ...]
         The stream of cluster data from cluster_arr_to_cent()
     estimate_energy : bool, optional
         Whether the data includes estimated energy sum (e_sum). Default is False.


### PR DESCRIPTION
An important aspect of processed Timepix data for many applications, including XPCS and X-ray SPDC, is that events are sorted by timestamp. Centroided data may also contain timestamps corrected for the timewalk effect; at CHX, this correction is applied by default. When corrected timestamps are available, they are assumed to provide a more accurate estimate of the true photon time-of-arrival (ToA) and should therefore be used for downstream analyses involving timing. Although rare, the timewalk correction can change the relative ordering of nearby events.

This commit therefore sorts events by the corrected ToA when available, ensuring that downstream analyses can assume the most accurate ToA is already time-sorted.