### PR TITLE
Handle Empty Files

### DIFF
--- a/src/tpx3awkward/processing/decoding.py
+++ b/src/tpx3awkward/processing/decoding.py
@@ -382,6 +382,9 @@ def decode_tpx3_binary(binary: NDArray[np.uint64], tdc: bool = False) -> tuple[p
        DataFrame of photon events parsed from the binary, and an optional TDC event DataFrame dependent on the
        ``tdc`` parameter.
     """
+    if binary.size == 0:
+        return None
+
     decoded_data = {
         k.strip(): v
         for k, v in zip(

--- a/src/tpx3awkward/processing/decoding.py
+++ b/src/tpx3awkward/processing/decoding.py
@@ -5,6 +5,8 @@ import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
 
+from .schemas import empty_raw_df, empty_tdc_df
+
 IA: TypeAlias = NDArray[np.uint64]
 UnSigned = TypeVar("UnSigned", IA, np.uint64)
 
@@ -383,7 +385,7 @@ def decode_tpx3_binary(binary: NDArray[np.uint64], tdc: bool = False) -> tuple[p
        ``tdc`` parameter.
     """
     if binary.size == 0:
-        return None
+        return empty_raw_df(), empty_tdc_df() if tdc else None
 
     decoded_data = {
         k.strip(): v

--- a/src/tpx3awkward/processing/schemas.py
+++ b/src/tpx3awkward/processing/schemas.py
@@ -19,7 +19,6 @@ def empty_raw_df() -> pd.DataFrame:
         "ToT": np.array([], dtype="u4"),  # uint32
         "t": np.array([], dtype="u8"),  # uint64
         "chip": np.array([], dtype="u1"),  # uint8
-        "cluster_id": np.array([], dtype="u8"),  # uint64
     }
 
     return pd.DataFrame(data)

--- a/src/tpx3awkward/processing/schemas.py
+++ b/src/tpx3awkward/processing/schemas.py
@@ -2,23 +2,16 @@ import numpy as np
 import pandas as pd
 
 
-def empty_raw_df(include_energy: bool = False) -> pd.DataFrame:
+def empty_raw_df() -> pd.DataFrame:
     """
-    Create an empty DataFrame with the expected columns from ingest_raw_data()
+    Create an empty event DataFrame with the expected columns from _ingest_raw_data()
     and the specified data types.
-
-    Parameters
-    ----------
-    include_energy : bool, optional
-        Whether to include the 'e' column (energy estimates). Default is False.
 
     Returns
     -------
     pd.DataFrame
         Empty DataFrame with columns:
-        ['x', 'y', 'ToT', 't', 'chip', 'cluster_id'] and appropriate dtypes
-        or
-        ['x', 'y', 'ToT', 'e', 't', 'chip', 'cluster_id'] if include_energy is True.
+        ['x', 'y', 'ToT', 't', 'chip'] and appropriate dtypes
     """
     data = {
         "x": np.array([], dtype="u2"),  # uint16
@@ -29,8 +22,25 @@ def empty_raw_df(include_energy: bool = False) -> pd.DataFrame:
         "cluster_id": np.array([], dtype="u8"),  # uint64
     }
 
-    if include_energy:
-        data["e"] = np.array([], dtype="float32")
+    return pd.DataFrame(data)
+
+
+def empty_tdc_df() -> pd.DataFrame:
+    """
+    Create an empty tdc DataFrame with the expected columns from _ingest_raw_data()
+    and the specified data types.
+
+    Returns
+    -------
+    pd.DataFrame
+        Empty DataFrame with columns:
+        ['tdc_t_ns', 'tdc_type', 'tdc_chip'] and appropriate dtypes
+    """
+    data = {
+        "tdc_t_ns": np.array([], dtype="f8"),
+        "tdc_type": np.array([], dtype=np.uint8),
+        "tdc_chip": np.array([], dtype=np.uint8),
+    }
 
     return pd.DataFrame(data)
 
@@ -42,8 +52,11 @@ def empty_cent_df(estimate_energy: bool = False, correct_timewalk: bool = False)
 
     Parameters
     ----------
-    include_energy : bool, optional
+    estimate_energy : bool, optional
         Whether to include the 'e_sum' column (energy estimates). Default is False.
+    correct_timewalk : bool, optional
+        Whether to include the 't_corr' column (timewalk correction). Default is False
+
 
     Returns
     -------

--- a/tests/processing/test_decoding.py
+++ b/tests/processing/test_decoding.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from tpx3awkward.processing.decoding import decode_tpx3_binary
@@ -67,3 +68,8 @@ def test_decode_tpx3_binary_no_tdc():
     required = {"tdc_t_ns", "tdc_type", "tdc_chip"}
     assert required.issubset(concat_tdc_df.columns)
     assert len(concat_tdc_df) == 0
+
+
+def test_decode_tpx3_binary_zero_bytes():
+    binary = np.array([], dtype=np.uint64)
+    _ = decode_tpx3_binary(binary)

--- a/tests/processing/test_decoding.py
+++ b/tests/processing/test_decoding.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from tpx3awkward.processing.decoding import decode_tpx3_binary
 from tpx3awkward.processing.files import raw_as_numpy
+from tpx3awkward.processing.schemas import empty_raw_df, empty_tdc_df
 
 RAW_DATA_DIR = Path(__file__).parents[1] / "data/raw"
 PROC_DATA_DIR = Path(__file__).parents[1] / "data/processed/"
@@ -72,4 +73,13 @@ def test_decode_tpx3_binary_no_tdc():
 
 def test_decode_tpx3_binary_zero_bytes():
     binary = np.array([], dtype=np.uint64)
-    _ = decode_tpx3_binary(binary)
+
+    # w/o tdc
+    df, _ = decode_tpx3_binary(binary)
+
+    pd.testing.assert_frame_equal(df, empty_raw_df())
+    # w tdc
+    df, tdc_df = decode_tpx3_binary(binary, tdc=True)
+
+    pd.testing.assert_frame_equal(df, empty_raw_df())
+    pd.testing.assert_frame_equal(tdc_df, empty_tdc_df())

--- a/tests/processing/test_pipeline.py
+++ b/tests/processing/test_pipeline.py
@@ -63,6 +63,28 @@ def test_convert_tpx3_binary_tdc():
     assert required_tdc.issubset(tdc_df.columns)
 
 
+def test_convert_tpx3_binary_zero_bytes():
+    path_to_data = RAW_DATA_DIR / "misc/zero_bytes.tpx3"
+    path_to_energy_parameters = CONFIG_DIR / "energy_estimation_test_parameters.npy"
+    energy_estimation_test_parameters = np.load(path_to_energy_parameters)
+    cdf, tdc_df = convert_tpx3_binary(
+        raw_as_numpy(path_to_data),
+        estimate_energy=True,
+        energy_estimation_parameters=energy_estimation_test_parameters,
+        correct_timewalk=True,
+        timewalk_b=167.0,
+        timewalk_c=-0.016,
+        tdc=True,
+        verbose=True,
+    )
+
+    required = {"t", "xc", "yc", "ToT_max", "ToT_sum", "n", "e_sum", "t_corr"}
+    assert required.issubset(cdf.columns)
+
+    required_tdc = {"tdc_t_ns", "tdc_type", "tdc_chip"}
+    assert required_tdc.issubset(tdc_df.columns)
+
+
 def test_convert_tpx3_file(tmp_path):
     path_to_data = RAW_DATA_DIR / "raw_test_data_01.tpx3"
     path_to_energy_parameters = CONFIG_DIR / "energy_estimation_test_parameters.npy"


### PR DESCRIPTION
Handle binary `.tpx3` files that have zero bytes by returning empty dataframes with expected structure.

Closes #37